### PR TITLE
origin insertion only in DOSE mode

### DIFF
--- a/BistroMath.lpi
+++ b/BistroMath.lpi
@@ -21,9 +21,10 @@
       <UseVersionInfo Value="True"/>
       <MajorVersionNr Value="4"/>
       <MinorVersionNr Value="5"/>
-      <RevisionNr Value="2"/>
-      <BuildNr Value="719"/>
+      <RevisionNr Value="3"/>
+      <BuildNr Value="720"/>
       <Language Value="0809"/>
+      <Attributes pvaPatched="True"/>
       <StringTable CompanyName="Theo van Soest" ProductName="BistroMath" ProductVersion="4"/>
     </VersionInfo>
     <BuildModes Count="3">
@@ -112,6 +113,11 @@
               </Win32>
             </Options>
           </Linking>
+          <Other>
+            <OtherDefines Count="1">
+              <Define0 Value="DEBUG"/>
+            </OtherDefines>
+          </Other>
         </CompilerOptions>
       </Item3>
     </BuildModes>

--- a/Wellhofer.pas
+++ b/Wellhofer.pas
@@ -1,4 +1,4 @@
-unit Wellhofer;  {© Theo van Soest Delphi: 01/08/2005-05/06/2020 | FPC 3.2.0: 29/10/2020}
+unit Wellhofer;  {© Theo van Soest Delphi: 01/08/2005-05/06/2020 | FPC 3.2.0: 30/10/2020}
 {$mode objfpc}{$h+}
 {$I BistroMath_opt.inc}
 
@@ -6351,11 +6351,12 @@ var i,s,LastLine: Integer;
 
   {01/06/2018}
   {10/02/2020 if twcMccInsertOrigin AND (MccOriginValue > 0) then}
+  {30/10/2020 ... AND (tmTaskName='DOSE'), also do nothing at all if not twcMccInsertOrigin}
   procedure InsertOrigin;
   var i,j,n: Integer;
   begin
   with MccData do
-    if tmScanDevice='STARCHECKMAXI' then                                        //current implementation only for StarCheckMaxi
+    if (tmScanDevice='STARCHECKMAXI') and twcMccInsertOrigin and (tmTaskName='DOSE') then //current implementation only for StarCheckMaxi, unreliable in DOSERATE mode
       begin
       n:= GetNumPoints;
       if  n>20 then
@@ -6368,7 +6369,7 @@ var i,s,LastLine: Integer;
           MccOriginValue:= tmData[i]                                            //and store that value
         else if tmPos_mm[Succ(i)]=0 then
           MccOriginValue:= tmData[Succ(i)]
-        else if twcMccInsertOrigin and (MccOriginValue>0) then                  //there is no origin, create it if there is a originvalue available
+        else if MccOriginValue>0 then                                           //there is no origin, create it if there is a originvalue available
           begin
           SetNumPoints(Succ(n));
           Inc(i);
@@ -6416,7 +6417,7 @@ if (FParseOk and (not CheckFileTypeOnly) and (FileFormat=twcMccProfile)) then wi
           NextLine;                                                             //tmRefField must be handled first because of conflict with FIELD_INPLANE
         LastLine:= FParser.CurrentLineNumber;
         MccFill(mccREF_                          ,tmRefField);                          {REF_FIELD_DEPTH=100.00}
-        MccFill(mccTASK_NAME                     ,tmTaskName);                          {TASK_NAME=tba PDD Profiles}
+        MccFill(mccTASK_NAME                     ,tmTaskName);                          {TASK_NAME=tba PDD Profiles; for StarCheck: DOSE | DOSERATE}
         MccFill(mccGROUP_NAME                    ,tmGroupName);                         {GROUP_NAME=TG_4.0}
         MccFill(mccPROGRAM                       ,tmProgram);                           {PROGRAM=tbaScan}
         MccFill(mccCOMMENT                       ,tmComment);                           {COMMENT=FFF Acceptance - 7 MV}

--- a/klemlogo.pas
+++ b/klemlogo.pas
@@ -30,8 +30,6 @@ type
     Xold,Yold  : Integer;
   end;
 
-const twVersionDate='24/10/2020';
-
 var AboutBox        : TAboutBox;
     BMBuildNumber   : Integer;
 
@@ -39,7 +37,7 @@ implementation
 
 uses StrUtils,
      Math,
-     TObaseDef,TOtools;
+     TObaseDef,TOtools,TOnumparser;
 
 {$R *.lfm}
 
@@ -71,15 +69,24 @@ var LogoStrings: array[1..15] of String=(
     LogoCnt,InsertPos: Integer;
 
 
+{30/10/2020 auto insertion of date}
 constructor TAboutBox.Create(AOwner: TComponent);
+var dt: TDateTime;
+    p : toTNumParser;
+    s : String;
 begin
 inherited;
-LogoCnt             := Length(LogoStrings);
-InsertPos           := Comments.Lines.Count;
-Comments .ParentFont:= False;
-Comments .Font.Color:= clBlack;    //why isn't this working???
-Version  .Caption   := Format('version %s (build %d)   %s',[GetAppVersionString(False),BMBuildNumber,twVersionDate]);
-CopyRight.Caption   := '© Theo van Soest, 2005 - '+RightStr(CharSetTrimAll(csComplete-csNumeric,twVersionDate),4);
+LogoCnt              := Length(LogoStrings);
+InsertPos            := Comments.Lines.Count;
+Comments .ParentFont := False;
+Comments .Font.Color := clBlack;                                                //why isn't this working???
+p                    := toTNumParser.Create;
+p        .CurrentLine:= {$I %DATE%};
+dt                   := p.NextDate;                                             //this procedure gives maximum flexibility
+s                    := FormatDateTime('DD/MM/YYYY',dt);
+Version  .Caption    := Format('version %s (build %d)   %s',[GetAppVersionString(False),BMBuildNumber,s]);
+CopyRight.Caption    := '© Theo van Soest, 2005 - '+RightStr(CharSetTrimAll(csComplete-csNumeric,s),4);
+p.Free;
 end; {~init}
 
 


### PR DESCRIPTION
For the StarCheckMaxi the insertion of the TG origin in other scans is problematic when in DOSERATE mode.
Auto-date value in AboutBox from compiler at compile time.