### PR TITLE
Wedge alignment bug and refactoring

### DIFF
--- a/BistroMath.lps
+++ b/BistroMath.lps
@@ -21,8 +21,8 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="WellForm"/>
-        <TopLine Value="2317"/>
-        <CursorPos X="17" Y="2346"/>
+        <TopLine Value="360"/>
+        <CursorPos X="61" Y="395"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -67,18 +67,18 @@
       </Unit5>
       <Unit6>
         <Filename Value="BistroMath_opt.inc"/>
+        <IsVisibleTab Value="True"/>
         <EditorIndex Value="6"/>
         <TopLine Value="69"/>
-        <CursorPos X="20" Y="88"/>
+        <CursorPos X="5" Y="88"/>
         <UsageCount Value="100"/>
         <Loaded Value="True"/>
       </Unit6>
       <Unit7>
         <Filename Value="Wellhofer.pas"/>
-        <IsVisibleTab Value="True"/>
         <EditorIndex Value="1"/>
         <TopLine Value="19670"/>
-        <CursorPos X="57" Y="19690"/>
+        <CursorPos Y="19687"/>
         <UsageCount Value="100"/>
         <Loaded Value="True"/>
       </Unit7>
@@ -756,122 +756,119 @@
     <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
         <Filename Value="wellform.pas"/>
-        <Caret Line="2661" Column="28" TopLine="2631"/>
+        <Caret Line="5084" TopLine="5056"/>
       </Position1>
       <Position2>
         <Filename Value="wellform.pas"/>
-        <Caret Line="2684" Column="26" TopLine="2655"/>
+        <Caret Line="5231" Column="14" TopLine="5201"/>
       </Position2>
       <Position3>
         <Filename Value="wellform.pas"/>
-        <Caret Line="2730" Column="26" TopLine="2701"/>
+        <Caret Line="5420" Column="14" TopLine="5390"/>
       </Position3>
       <Position4>
         <Filename Value="wellform.pas"/>
-        <Caret Line="2771" Column="26" TopLine="2742"/>
+        <Caret Line="6494" TopLine="6465"/>
       </Position4>
       <Position5>
         <Filename Value="wellform.pas"/>
-        <Caret Line="2777" Column="21" TopLine="2748"/>
+        <Caret Line="6847" TopLine="6818"/>
       </Position5>
       <Position6>
         <Filename Value="wellform.pas"/>
-        <Caret Line="2814" Column="103" TopLine="2785"/>
+        <Caret Line="10670" TopLine="10641"/>
       </Position6>
       <Position7>
         <Filename Value="wellform.pas"/>
-        <Caret Line="2929" Column="28" TopLine="2900"/>
+        <Caret Line="395" Column="22" TopLine="377"/>
       </Position7>
       <Position8>
         <Filename Value="wellform.pas"/>
-        <Caret Line="3221" Column="32" TopLine="3192"/>
+        <Caret Line="4689" Column="35" TopLine="4673"/>
       </Position8>
       <Position9>
         <Filename Value="wellform.pas"/>
-        <Caret Line="3237" Column="24" TopLine="3208"/>
       </Position9>
       <Position10>
         <Filename Value="wellform.pas"/>
-        <Caret Line="3238" Column="65" TopLine="3209"/>
+        <Caret Line="395" Column="22" TopLine="365"/>
       </Position10>
       <Position11>
         <Filename Value="wellform.pas"/>
+        <Caret Line="862" Column="20" TopLine="833"/>
       </Position11>
       <Position12>
         <Filename Value="wellform.pas"/>
-        <Caret Line="1004" Column="15" TopLine="975"/>
+        <Caret Line="896" Column="29" TopLine="867"/>
       </Position12>
       <Position13>
         <Filename Value="wellform.pas"/>
-        <Caret Line="1704" Column="11" TopLine="1675"/>
+        <Caret Line="996" Column="20" TopLine="967"/>
       </Position13>
       <Position14>
         <Filename Value="wellform.pas"/>
-        <Caret Line="1706" Column="19" TopLine="1677"/>
+        <Caret Line="1030" Column="115" TopLine="1001"/>
       </Position14>
       <Position15>
         <Filename Value="wellform.pas"/>
-        <Caret Line="2346" Column="9" TopLine="2315"/>
+        <Caret Line="1031" Column="115" TopLine="1002"/>
       </Position15>
       <Position16>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="54" Column="19" TopLine="43"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="1032" Column="115" TopLine="1003"/>
       </Position16>
       <Position17>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="760" Column="20" TopLine="730"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="1558" Column="6" TopLine="1528"/>
       </Position17>
       <Position18>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="2914" Column="44" TopLine="2886"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="2470" Column="127" TopLine="2448"/>
       </Position18>
       <Position19>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="4200" Column="15" TopLine="4170"/>
+        <Filename Value="wellform.pas"/>
       </Position19>
       <Position20>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="8846" Column="28" TopLine="8816"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="1138" Column="27" TopLine="1123"/>
       </Position20>
       <Position21>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="8858" Column="54" TopLine="8828"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="1137" Column="27" TopLine="1122"/>
       </Position21>
       <Position22>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="8930" Column="28" TopLine="8901"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="2476" TopLine="2463"/>
       </Position22>
       <Position23>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="8931" Column="60" TopLine="8902"/>
+        <Filename Value="wellform.pas"/>
       </Position23>
       <Position24>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="8933" Column="61" TopLine="8904"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="896" TopLine="872"/>
       </Position24>
       <Position25>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="14241" Column="23" TopLine="14212"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="2478" Column="30" TopLine="2449"/>
       </Position25>
       <Position26>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="19687" Column="83" TopLine="19658"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="4699" TopLine="4699"/>
       </Position26>
       <Position27>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="19681" Column="68" TopLine="19658"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="11686" Column="5" TopLine="11677"/>
       </Position27>
       <Position28>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="4416" TopLine="4397"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="2208" Column="27" TopLine="2191"/>
       </Position28>
       <Position29>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="4417" TopLine="4397"/>
+        <Filename Value="wellform.pas"/>
+        <Caret Line="2465" Column="42" TopLine="2448"/>
       </Position29>
       <Position30>
-        <Filename Value="Wellhofer.pas"/>
-        <Caret Line="19687" Column="144" TopLine="19670"/>
+        <Filename Value="wellform.pas"/>
       </Position30>
     </JumpHistory>
     <RunParams>
@@ -935,7 +932,7 @@
         <WatchScope Value="wpsLocal"/>
         <WatchKind Value="wpkWrite"/>
         <Source Value="wellform.pas"/>
-        <Line Value="6491"/>
+        <Line Value="6506"/>
       </Item>
     </BreakPoints>
     <Watches>

--- a/BistroMath_opt.inc
+++ b/BistroMath_opt.inc
@@ -85,7 +85,7 @@
 {$ENDIF}
 
 {$IFDEF Windows}
-{$DEFINE JwaWinBase}
+  {$DEFINE JwaWinBase}
 {$ENDIF}
 
 

--- a/wellform.pas
+++ b/wellform.pas
@@ -392,7 +392,7 @@ type
   21/01/2023
     added StructuredDataSetsLabel,StructuredDataSetsList,FocusPositionStructuredData
   20/02/2023
-    added GetCpuUsage for StatusBar.Panels[3]
+    added GetCpuUsage for StatusBar.Panels[3] and FIdleTimer
   }
 
   {=========== TAnalyseForm =====================}
@@ -890,6 +890,9 @@ type
     procedure FileOpenClick            (Sender         : TObject);                //uses DataFileOpen
     procedure FileOpenTempRefClick     (Sender         : TObject);                //uses TWellhoferData to open
     procedure FileSaveClick            (Sender         : TObject);
+    {$IFDEF JwaWinBase}
+    procedure OnIdleTimer              (Sender         : TObject);
+    {$ENDIF}
     {$IFDEF form2pdf}
     procedure FilePrintFormClick       (Sender         : TObject);
     {$ENDIF}
@@ -1133,6 +1136,7 @@ type
     FLastKernelTime       : Int64;
     FPerformanceFrequency : Int64;
     FLastUserTime         : Int64;
+    FIdleTimer            : TIdleTimer;
    {$ENDIF}
    {$IFDEF SelfTest}
     SelfTestItem          : TMenuItem;
@@ -2467,7 +2471,13 @@ with SpecialMode[1] do
   else
     SetCaption;
 {$ENDIF}
-ClipBoardLock             := False;                                             //finally unlock clipboard
+ClipBoardLock        := False;                                                  //finally unlock clipboard
+{$IFDEF JwaWinBase}
+FIdleTimer:= TIdleTimer.Create(Self);
+FIdleTimer.Interval   := 10000;
+FIdleTimer.AutoEnabled:= True;
+FIdleTimer.OnTimer    := @OnIdleTimer;
+{$ENDIF}
 end; {~formcreate}
 
 
@@ -4721,6 +4731,15 @@ MeasCalcPDDfitClick(Sender);
 end; {~measmenuclick}
 
 
+{$IFDEF JwaWinBase}
+{20/02/2023}
+procedure TAnalyseForm.OnIdleTimer(Sender: TObject);
+begin
+GetCpuUsage(True,10);
+end; {~onidletimer}
+{$ENDIF}
+
+
 {18/09/2015 loglevel}
 {17/12/2015 DataPlot.xxAxis.Font.Color change removed}
 {05/05/2020 dataplot colors synchronised}
@@ -5074,9 +5093,6 @@ if (Sender=SimpleModeItem) or (Sender=ViewNoDefaultAnnotationItem) then
   ClearAllCx;
   PublishResults;
   end;
-{$IFDEF JwaWinBase}
-GetCpuUsage(True,10);
-{$ENDIF}
 end; {~uimodechange}
 
 
@@ -6487,9 +6503,6 @@ while OnDataReadBusy and (l>0) do
   WaitLoop(100);
   Dec(l);
   end;
-{$IFDEF JwaWinBase}
-GetCpuUsage(True,10);
-{$ENDIF}
 if Sender=FileExitItem then
   Close
 else if Sender=AboutItem then
@@ -6843,9 +6856,6 @@ var i: Integer;
   end;
 
 begin
-{$IFDEF JwaWinBase}
-GetCpuUsage(False);
-{$ENDIF}
 ClipBoardLock:= False;
 {$IFDEF PRELOAD}
 PreloadTransfer(Sender);
@@ -10669,9 +10679,6 @@ var i,j,k: Integer;
     c    : Char;
     b    : Boolean;
 begin
-{$IFDEF JwaWinBase}
-GetCpuUsage(False);
-{$ENDIF}
 b:= (PageControl.ActivePage=ConfigurationTab) or (PageControl.ActivePage=AliasTab) or
     (PageControl.ActivePage=SettingsTab)      or (PageControl.ActivePage=AdvancedSettingsTab);
 k:= 0;                                                                          //limit autolooping


### PR DESCRIPTION
Minor bug fix: Even with Wedge detection on, alignment could lead to a wrong center position for very wide wedged fields and resulting in unreliable alignment for the reference. This could be corrected with a reload of the profile. Now the edge found through the derivative is used when for the derivative is concluded that a wedged profile is found.

Slightly faster analysis by avoiding recalculation of cpu-intensive results if already available.

A CPU load indicator and a Field Type have been added to the statusbar.

The functionality of the Processing option Mirrored measurement as Reference is extended to all profiles in the history list.